### PR TITLE
[AD-4325] Upgrade to node version 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,13 +109,13 @@ workflows:
   integrity_check:
     jobs:
       - run_tests_job:
-          name: Node 14
-          image_tag: v14
+          name: Node 16
+          image_tag: v16
 
   publish:
     jobs:
       - run_tests_job:
-          image_tag: v14
+          image_tag: v16
           persist_workspace: true
           filters:
             tags:
@@ -124,7 +124,7 @@ workflows:
               ignore: /.*/
 
       - publish_job:
-          image_tag: v14
+          image_tag: v16
           requires:
             - run_tests_job
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed/Updated
 
+- Update `node` to version 16 ([#12][12])
+
+[12]: https://github.com/pantheon-systems/eslint-config-pantheon/pull/12
+
 ## 0.2.0
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "engineering@pantheon.io",
   "description": "A collection of Pantheon's ESLint configurations",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this PR do?
- Update to the latest node LTS version 16.13.2

## Other considerations
- Branch rules are updated to reflect the new node version

## Resources

- [Jira ticket](https://getpantheon.atlassian.net/browse/AD-4325)
